### PR TITLE
Use ^https://github.com/actionutils/trusted-tag-releaser as default certificate-identity-regexp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,20 @@ on:
       - labeled  # Run when PRs are labeled
 
 jobs:
+  verify-releaser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify Trusted Tag Releaser
+        uses: ./
+        with:
+          repository: 'actionutils/trusted-tag-releaser'
+          tag: 'v0'
+
   # Post version bump information comment on PR when labeled
   release-preview-comment:
+    needs: [verify-releaser]
     if: github.event.action == 'labeled'
     permissions:
       pull-requests: write
@@ -20,6 +32,7 @@ jobs:
 
   # First check if a release is needed
   release-check:
+    needs: [verify-releaser]
     if: github.event.action != 'labeled'
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v4
       - name: Verify Trusted Tag Releaser
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           echo "Commit: ${{ steps.verify-shorthand.outputs.commit-sha }}"
           echo "Tagger: ${{ steps.verify-shorthand.outputs.tagger-name }} <${{ steps.verify-shorthand.outputs.tagger-email }}>"
           echo "Message: ${{ steps.verify-shorthand.outputs.tag-message }}"
-          
+
           # Display the full JSON
           echo "Verification Result (JSON):"
           echo '${{ steps.verify-shorthand.outputs.verification-result }}' | jq
@@ -56,7 +56,7 @@ jobs:
           echo "Commit: ${{ steps.verify-explicit.outputs.commit-sha }}"
           echo "Tagger: ${{ steps.verify-explicit.outputs.tagger-name }} <${{ steps.verify-explicit.outputs.tagger-email }}>"
           echo "Message: ${{ steps.verify-explicit.outputs.tag-message }}"
-          
+
           # Display the full JSON
           echo "Verification Result (JSON):"
           echo '${{ steps.verify-explicit.outputs.verification-result }}' | jq

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This action verifies that Git tags are properly signed with Gitsign, extracts th
     tag: 'v1.0.0'
     fail-on-verification-error: 'true'
     certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
-    certificate-identity-regexp: '^https://github.com/'
+    certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
 
 - name: Use Verification Results
   run: |
@@ -47,7 +47,7 @@ This action verifies that Git tags are properly signed with Gitsign, extracts th
     echo "Commit: ${{ steps.verify.outputs.commit-sha }}"
     echo "Tagger: ${{ steps.verify.outputs.tagger-name }} <${{ steps.verify.outputs.tagger-email }}>"
     echo "Message: ${{ steps.verify.outputs.tag-message }}"
-    
+
     # Access specific fields from the verification result
     TAG_NAME=$(echo '${{ steps.verify.outputs.verification-result }}' | jq -r '.tag.name')
     echo "Tag name from result: $TAG_NAME"
@@ -62,7 +62,7 @@ This action verifies that Git tags are properly signed with Gitsign, extracts th
 | `tag` | The name of the tag to verify (ignored if `verify` is provided) | No | N/A |
 | `fail-on-verification-error` | Whether to fail the action if verification fails | No | `true` |
 | `certificate-oidc-issuer` | The OIDC issuer to verify against | No | `https://token.actions.githubusercontent.com` |
-| `certificate-identity-regexp` | The identity regexp to verify against | No | `^https://github.com/` |
+| `certificate-identity-regexp` | The identity regexp to verify against | No | `^https://github.com/actionutils/trusted-tag-releaser` |
 
 **Note**: Either `verify` OR both `repository` and `tag` must be provided.
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   certificate-identity-regexp:
     description: 'The identity regexp to verify against'
     required: false
-    default: '^https://github.com/'
+    default: '^https://github.com/actionutils/trusted-tag-releaser'
 
 outputs:
   verified:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a pre-release verification step that ensures only trusted, validated releases are processed.

- **Documentation**
  - Updated certificate identity guidelines to specify a more restrictive, trusted source for release validation.

- **Chores**
  - Improved log output formatting for enhanced readability during verification and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->