### PR TITLE
Unify input format to use verify parameter only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Verify Trusted Tag Releaser
         uses: ./
         with:
-          repository: 'actionutils/trusted-tag-releaser'
-          tag: 'v0'
+          verify: 'actionutils/trusted-tag-releaser@v0'
 
   # Post version bump information comment on PR when labeled
   release-preview-comment:
@@ -69,4 +68,3 @@ jobs:
     uses: actionutils/trusted-tag-releaser/.github/workflows/trusted-release-workflow.yml@v0
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,14 +103,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # First download an action so it exists in the runner workspace
-      - name: Use trusted-tag-verifier as a target (to download it)
-        uses: actionutils/trusted-tag-verifier@v0
-        with:
-          verify: 'actionutils/trusted-tag-releaser@v0'
-
-      # Now test with no @ref - it should detect the downloaded action
+      # Test with no @ref - it should detect the downloaded action
       - name: Test with no @ref (should use downloaded action)
         uses: ./
         with:
           verify: 'actionutils/trusted-tag-verifier'
+
+      # Now use the actual trusted-tag-verifier that was pre-downloaded by the runner
+      - name: Use trusted-tag-verifier as a target
+        uses: actionutils/trusted-tag-verifier@v0
+        with:
+          verify: 'actionutils/trusted-tag-releaser@v0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,26 +40,6 @@ jobs:
           echo "Verification Result (JSON):"
           echo '${{ steps.verify-shorthand.outputs.verification-result }}' | jq
 
-      - name: Verify Tag (With fail-on-verification-error false)
-        id: verify-no-fail
-        uses: ./
-        with:
-          verify: 'actionutils/trusted-tag-releaser@v0.0.30'
-          fail-on-verification-error: 'false'
-
-      - name: Display Verification Results (With fail-on-verification-error false)
-        run: |
-          echo "Verified: ${{ steps.verify-no-fail.outputs.verified }}"
-          echo "Repository: ${{ steps.verify-no-fail.outputs.repository }}"
-          echo "Tag: ${{ steps.verify-no-fail.outputs.tag-name }}"
-          echo "Commit: ${{ steps.verify-no-fail.outputs.commit-sha }}"
-          echo "Tagger: ${{ steps.verify-no-fail.outputs.tagger-name }} <${{ steps.verify-no-fail.outputs.tagger-email }}>"
-          echo "Message: ${{ steps.verify-no-fail.outputs.tag-message }}"
-
-          # Display the full JSON
-          echo "Verification Result (JSON):"
-          echo '${{ steps.verify-no-fail.outputs.verification-result }}' | jq
-
       - name: Test Invalid Tag (Should Fail)
         id: verify-invalid-tag
         uses: ./
@@ -114,8 +94,8 @@ jobs:
             exit 1
           fi
 
-  test-verify-format:
-    name: Test Verify Format
+  test-downloaded-action:
+    name: Test Downloaded Action Path Detection
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -123,7 +103,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Use trusted-tag-verifier as a target
+      # First download an action so it exists in the runner workspace
+      - name: Use trusted-tag-verifier as a target (to download it)
         uses: actionutils/trusted-tag-verifier@v0
         with:
           verify: 'actionutils/trusted-tag-releaser@v0'
+
+      # Now test with no @ref - it should detect the downloaded action
+      - name: Test with no @ref (should use downloaded action)
+        uses: ./
+        with:
+          verify: 'actionutils/trusted-tag-verifier'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,26 +40,25 @@ jobs:
           echo "Verification Result (JSON):"
           echo '${{ steps.verify-shorthand.outputs.verification-result }}' | jq
 
-      - name: Verify Tag (Explicit Parameters)
-        id: verify-explicit
+      - name: Verify Tag (With fail-on-verification-error false)
+        id: verify-no-fail
         uses: ./
         with:
-          repository: 'actionutils/trusted-tag-releaser'
-          tag: 'v0.0.30'
+          verify: 'actionutils/trusted-tag-releaser@v0.0.30'
           fail-on-verification-error: 'false'
 
-      - name: Display Verification Results (Explicit Parameters)
+      - name: Display Verification Results (With fail-on-verification-error false)
         run: |
-          echo "Verified: ${{ steps.verify-explicit.outputs.verified }}"
-          echo "Repository: ${{ steps.verify-explicit.outputs.repository }}"
-          echo "Tag: ${{ steps.verify-explicit.outputs.tag-name }}"
-          echo "Commit: ${{ steps.verify-explicit.outputs.commit-sha }}"
-          echo "Tagger: ${{ steps.verify-explicit.outputs.tagger-name }} <${{ steps.verify-explicit.outputs.tagger-email }}>"
-          echo "Message: ${{ steps.verify-explicit.outputs.tag-message }}"
+          echo "Verified: ${{ steps.verify-no-fail.outputs.verified }}"
+          echo "Repository: ${{ steps.verify-no-fail.outputs.repository }}"
+          echo "Tag: ${{ steps.verify-no-fail.outputs.tag-name }}"
+          echo "Commit: ${{ steps.verify-no-fail.outputs.commit-sha }}"
+          echo "Tagger: ${{ steps.verify-no-fail.outputs.tagger-name }} <${{ steps.verify-no-fail.outputs.tagger-email }}>"
+          echo "Message: ${{ steps.verify-no-fail.outputs.tag-message }}"
 
           # Display the full JSON
           echo "Verification Result (JSON):"
-          echo '${{ steps.verify-explicit.outputs.verification-result }}' | jq
+          echo '${{ steps.verify-no-fail.outputs.verification-result }}' | jq
 
       - name: Test Invalid Tag (Should Fail)
         id: verify-invalid-tag
@@ -82,8 +81,7 @@ jobs:
         id: verify-invalid-issuer
         uses: ./
         with:
-          repository: 'actionutils/trusted-tag-releaser'
-          tag: 'v0.0.30'
+          verify: 'actionutils/trusted-tag-releaser@v0.0.30'
           certificate-oidc-issuer: 'https://invalid-issuer.example.com'
           fail-on-verification-error: 'false'
 
@@ -102,8 +100,7 @@ jobs:
         id: verify-invalid-issuer-fail
         uses: ./
         with:
-          repository: 'actionutils/trusted-tag-releaser'
-          tag: 'v0.0.30'
+          verify: 'actionutils/trusted-tag-releaser@v0.0.30'
           certificate-oidc-issuer: 'https://invalid-issuer.example.com'
           fail-on-verification-error: 'true'
         continue-on-error: true
@@ -117,20 +114,14 @@ jobs:
             exit 1
           fi
 
-  test-downloaded-action:
-    name: Test Downloaded Action Path Detection
+  test-verify-format:
+    name: Test Verify Format
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
       - uses: actions/checkout@v5
-
-      # Now test with empty tag - it should detect the downloaded action
-      - name: Test with empty tag (should use downloaded action)
-        uses: ./
-        with:
-          repository: 'actionutils/trusted-tag-verifier'
 
       - name: Use trusted-tag-verifier as a target
         uses: actionutils/trusted-tag-verifier@v0

--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,7 @@ branding:
 inputs:
   verify:
     description: 'The repository and tag to verify in the format <owner>/<repo>@<version>'
-    required: false
-  repository:
-    description: 'The repository containing the tag to verify (ignored if verify is provided)'
-    required: false
-  tag:
-    description: 'The name of the tag to verify (ignored if verify is provided). If omitted with repository, auto-detects from downloaded action in runner workspace'
-    required: false
+    required: true
   fail-on-verification-error:
     description: 'Whether to fail the action if verification fails'
     required: false
@@ -68,7 +62,7 @@ runs:
     - name: Parse inputs
       id: parse-inputs
       shell: bash
-      run: ${{ github.action_path }}/scripts/parse-inputs.sh "${{ inputs.verify }}" "${{ inputs.repository }}" "${{ inputs.tag }}"
+      run: ${{ github.action_path }}/scripts/parse-inputs.sh "${{ inputs.verify }}"
 
     - name: Validate inputs
       id: validate-inputs

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 
 inputs:
   verify:
-    description: 'The repository and tag to verify in the format <owner>/<repo>@<version>'
+    description: 'The repository and tag to verify in the format <owner>/<repo>@<version> or <owner>/<repo> (auto-detects from downloaded action)'
     required: true
   fail-on-verification-error:
     description: 'Whether to fail the action if verification fails'

--- a/scripts/parse-inputs.sh
+++ b/scripts/parse-inputs.sh
@@ -2,52 +2,21 @@
 set -e
 
 echo "::group::Parsing inputs"
-if [[ -n "$1" ]]; then
-  # Parse the verify input in the format <owner>/<repo>@<version>
-  REPO=$(echo "$1" | cut -d '@' -f 1)
-  TAG=$(echo "$1" | cut -d '@' -f 2)
-  echo "repository=$REPO" >> $GITHUB_OUTPUT
-  echo "tag=$TAG" >> $GITHUB_OUTPUT
-  echo "Using verify parameter: $REPO@$TAG"
-else
-  # Use the repository and tag inputs directly
-  REPOSITORY="$2"
-  TAG="$3"
-
-  # If tag is empty and repository is provided, check for downloaded action
-  if [[ -z "$TAG" && -n "$REPOSITORY" ]]; then
-    # Check if we're in a GitHub Actions environment and can use the downloaded action path
-    if [[ -n "$RUNNER_WORKSPACE" ]]; then
-      # Parse repository to get owner and repo
-      OWNER=$(echo "$REPOSITORY" | cut -d '/' -f 1)
-      REPO=$(echo "$REPOSITORY" | cut -d '/' -f 2)
-
-      # Look for downloaded action in $(dirname "$RUNNER_WORKSPACE")/_actions/<owner>/<repo>/
-      ACTIONS_DIR="$(dirname "$RUNNER_WORKSPACE")/_actions"
-      ACTION_PATH="$ACTIONS_DIR/$OWNER/$REPO"
-
-      if [[ -d "$ACTION_PATH" ]]; then
-        echo "::notice::Tag not provided, checking for downloaded action at $ACTION_PATH"
-
-        # Find the most recent ref directory only; ignore watermark files like
-        # "<ref>.completed" that the runner creates.
-        # ref: https://github.com/actions/runner/blame/f9c4e17fd98db89cd9b1f05f156a9f7a8562522d/src/Runner.Worker/ActionManager.cs#L932
-        latest_dir=$(ls -1td -- "$ACTION_PATH"/*/ 2>/dev/null | head -n 1)
-        REF=""
-        if [[ -n "$latest_dir" ]]; then
-          REF="$(basename "$latest_dir")"
-        fi
-
-        if [[ -n "$REF" ]]; then
-          TAG="$REF"
-          echo "::notice::Using downloaded action reference: $TAG"
-        fi
-      fi
-    fi
-  fi
-
-  echo "repository=$REPOSITORY" >> $GITHUB_OUTPUT
-  echo "tag=$TAG" >> $GITHUB_OUTPUT
-  echo "Using repository and tag parameters: $REPOSITORY@$TAG"
+if [[ -z "$1" ]]; then
+  echo "::error::The 'verify' input is required in the format <owner>/<repo>@<version>"
+  exit 1
 fi
+
+# Parse the verify input in the format <owner>/<repo>@<version>
+REPO=$(echo "$1" | cut -d '@' -f 1)
+TAG=$(echo "$1" | cut -d '@' -f 2)
+
+if [[ -z "$REPO" || -z "$TAG" || "$REPO" == "$TAG" ]]; then
+  echo "::error::Invalid verify format. Expected: <owner>/<repo>@<version>, got: $1"
+  exit 1
+fi
+
+echo "repository=$REPO" >> $GITHUB_OUTPUT
+echo "tag=$TAG" >> $GITHUB_OUTPUT
+echo "Using verify parameter: $REPO@$TAG"
 echo "::endgroup::"

--- a/scripts/parse-inputs.sh
+++ b/scripts/parse-inputs.sh
@@ -3,20 +3,75 @@ set -e
 
 echo "::group::Parsing inputs"
 if [[ -z "$1" ]]; then
-  echo "::error::The 'verify' input is required in the format <owner>/<repo>@<version>"
+  echo "::error::The 'verify' input is required in the format <owner>/<repo>@<version> or <owner>/<repo>"
   exit 1
 fi
 
-# Parse the verify input in the format <owner>/<repo>@<version>
-REPO=$(echo "$1" | cut -d '@' -f 1)
-TAG=$(echo "$1" | cut -d '@' -f 2)
+# Check if the input contains @ separator
+if [[ "$1" == *"@"* ]]; then
+  # Parse the verify input in the format <owner>/<repo>@<version>
+  REPO=$(echo "$1" | cut -d '@' -f 1)
+  TAG=$(echo "$1" | cut -d '@' -f 2)
 
-if [[ -z "$REPO" || -z "$TAG" || "$REPO" == "$TAG" ]]; then
-  echo "::error::Invalid verify format. Expected: <owner>/<repo>@<version>, got: $1"
-  exit 1
+  if [[ -z "$REPO" || -z "$TAG" ]]; then
+    echo "::error::Invalid verify format. Expected: <owner>/<repo>@<version>, got: $1"
+    exit 1
+  fi
+
+  echo "repository=$REPO" >> $GITHUB_OUTPUT
+  echo "tag=$TAG" >> $GITHUB_OUTPUT
+  echo "Using verify parameter: $REPO@$TAG"
+else
+  # No @ separator, format is <owner>/<repo>
+  REPOSITORY="$1"
+  TAG=""
+
+  # Validate repository format
+  if [[ ! "$REPOSITORY" =~ ^[^/]+/[^/]+$ ]]; then
+    echo "::error::Invalid repository format. Expected: <owner>/<repo>, got: $REPOSITORY"
+    exit 1
+  fi
+
+  # Check if we're in a GitHub Actions environment and can use the downloaded action path
+  if [[ -n "$RUNNER_WORKSPACE" ]]; then
+    # Parse repository to get owner and repo
+    OWNER=$(echo "$REPOSITORY" | cut -d '/' -f 1)
+    REPO=$(echo "$REPOSITORY" | cut -d '/' -f 2)
+
+    # Look for downloaded action in $(dirname "$RUNNER_WORKSPACE")/_actions/<owner>/<repo>/
+    ACTIONS_DIR="$(dirname "$RUNNER_WORKSPACE")/_actions"
+    ACTION_PATH="$ACTIONS_DIR/$OWNER/$REPO"
+
+    if [[ -d "$ACTION_PATH" ]]; then
+      echo "::notice::Tag not provided, checking for downloaded action at $ACTION_PATH"
+
+      # Find the most recent ref directory only; ignore watermark files like
+      # "<ref>.completed" that the runner creates.
+      # ref: https://github.com/actions/runner/blame/f9c4e17fd98db89cd9b1f05f156a9f7a8562522d/src/Runner.Worker/ActionManager.cs#L932
+      latest_dir=$(ls -1td -- "$ACTION_PATH"/*/ 2>/dev/null | head -n 1)
+      REF=""
+      if [[ -n "$latest_dir" ]]; then
+        REF="$(basename "$latest_dir")"
+      fi
+
+      if [[ -n "$REF" ]]; then
+        TAG="$REF"
+        echo "::notice::Using downloaded action reference: $TAG"
+      else
+        echo "::error::No downloaded action found for $REPOSITORY"
+        exit 1
+      fi
+    else
+      echo "::error::No @ separator provided and no downloaded action found for $REPOSITORY"
+      exit 1
+    fi
+  else
+    echo "::error::No @ separator provided and not in GitHub Actions environment"
+    exit 1
+  fi
+
+  echo "repository=$REPOSITORY" >> $GITHUB_OUTPUT
+  echo "tag=$TAG" >> $GITHUB_OUTPUT
+  echo "Using repository with auto-detected tag: $REPOSITORY@$TAG"
 fi
-
-echo "repository=$REPO" >> $GITHUB_OUTPUT
-echo "tag=$TAG" >> $GITHUB_OUTPUT
-echo "Using verify parameter: $REPO@$TAG"
 echo "::endgroup::"


### PR DESCRIPTION
## Summary
- Remove deprecated `repository` and `tag` inputs
- Keep only the `verify` input with format `<owner>/<repo>@<version>`
- Update test workflows to use the unified format

## Breaking Changes
This is a breaking change. The `repository` and `tag` inputs are no longer supported. All users must migrate to using the `verify` input with the format `<owner>/<repo>@<version>`.

## Migration Guide
Before:
```yaml
uses: actionutils/trusted-tag-verifier@v0
with:
  repository: 'owner/repo'
  tag: 'v1.0.0'
```

After:
```yaml
uses: actionutils/trusted-tag-verifier@v0
with:
  verify: 'owner/repo@v1.0.0'
```

🤖 Generated with [Claude Code](https://claude.ai/code)