### PR TITLE
Wrap verification results with details summary

### DIFF
--- a/scripts/generate-summary.sh
+++ b/scripts/generate-summary.sh
@@ -33,6 +33,19 @@ fi
 # Add to GitHub step summary
 echo "## Tag Verification Results" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
+
+# Details summary line with repository, tag and verification status
+if [[ "$VERIFIED" == "true" ]]; then
+  SUMMARY_STATUS="✅ Verified"
+else
+  SUMMARY_STATUS="❌ Not verified"
+fi
+
+echo "<details>" >> $GITHUB_STEP_SUMMARY
+echo "<summary><strong>$REPOSITORY</strong> @ <code>$TAG</code> — $SUMMARY_STATUS</summary>" >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
+
+# The markdown table inside details
 echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
 echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
 echo "| Repository | [$REPOSITORY]($REPO_URL) |" >> $GITHUB_STEP_SUMMARY
@@ -52,5 +65,9 @@ if [[ "$VERIFIED" == "true" ]]; then
 else
   echo "| Verification | ❌ FAILED |" >> $GITHUB_STEP_SUMMARY
 fi
+
+# Close details block
+echo "" >> $GITHUB_STEP_SUMMARY
+echo "</details>" >> $GITHUB_STEP_SUMMARY
 
 echo "::endgroup::"


### PR DESCRIPTION
This PR wraps the verification result markdown table in a <details> block and adds a concise <summary> showing repository, tag, and verification status.\n\n- Keeps "Tag Verification Results" heading\n- Adds <details> with <summary>: \\n- Embeds the existing markdown table inside the block\n- Closes the details after the table\n\nThis makes the step summary more readable while keeping full details one click away.