### PR TITLE
Add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Trusted Tag Verifier
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/actionutils/trusted-tag-verifier/badge)](https://scorecard.dev/viewer/?uri=github.com/actionutils/trusted-tag-verifier)
+
 A GitHub Action to verify tags signed with [Gitsign](https://github.com/sigstore/gitsign) and display their contents.
 
 ## Overview


### PR DESCRIPTION
## Summary
- Add OpenSSF Scorecard badge to provide visibility into the project's security posture
- Badge displays the current scorecard rating with a link to detailed results

## Test plan
- [x] Verify badge renders correctly in README
- [x] Confirm badge link points to the correct scorecard viewer URL

🤖 Generated with [Claude Code](https://claude.ai/code)