### PR TITLE
Add cleanup step for __tag_verifier_target__ directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,3 +132,11 @@ runs:
           "${{ inputs.certificate-oidc-issuer }}" \
           "${{ inputs.certificate-identity-regexp }}" \
           "${{ steps.verify-tag.outputs.tlog-index }}"
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: |
+        if [ -d "__tag_verifier_target__" ]; then
+          rm -rf __tag_verifier_target__
+        fi


### PR DESCRIPTION
## Summary
- Add a cleanup step that always runs to remove the temporary `__tag_verifier_target__` directory
- Prevents leaving behind unnecessary files in the runner's workspace

## Test plan
- [ ] Run the action and verify the `__tag_verifier_target__` directory is removed after completion
- [ ] Test with both successful and failed verification scenarios to ensure cleanup runs with `if: always()`

🤖 Generated with [Claude Code](https://claude.ai/code)